### PR TITLE
Fix ipv4 only launch

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -2,7 +2,7 @@
 
 # Given the new defaut of expecting ipv6 to be enabled, handle its absence
 ADMIN_ADDRESS=""
-inet6=$(/usr/sbin/ip a 2>&1 | grep -c 'inet6')
+inet6=$(ip a | grep -c inet6)
 if [ $inet6 -eq 0 ]; then
     ADMIN_ADDRESS="--admin-address 0.0.0.0"
 fi


### PR DESCRIPTION
**Given**
The latest 4.2 release defaults to ipv4 and ipv6

**When**
ipv6 is disabled in the host kernel, the application fails to start

**Then**
This patch detects if ipv6 is disabled, and takes appropriate measures to allow startup in an ipv4-only scenario.